### PR TITLE
애플 제품별 카테고리 추가

### DIFF
--- a/src/main/kotlin/backend/itracker/crawl/common/ProductCategory.kt
+++ b/src/main/kotlin/backend/itracker/crawl/common/ProductCategory.kt
@@ -1,0 +1,6 @@
+package backend.itracker.crawl.common
+
+enum class ProductCategory {
+    MACBOOK_AIR,
+    MACBOOK_PRO
+}

--- a/src/main/kotlin/backend/itracker/crawl/macbook/domain/Macbook.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/domain/Macbook.kt
@@ -1,6 +1,7 @@
 package backend.itracker.crawl.macbook.domain
 
 import backend.itracker.crawl.common.BaseEntity
+import backend.itracker.crawl.common.ProductCategory
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -15,7 +16,7 @@ class Macbook(
     @Column(columnDefinition = "TEXT")
     val name: String,
 
-    val type: String,
+    val category: ProductCategory,
     val cpu: String,
     val gpu: String,
     val storage: String,
@@ -54,6 +55,6 @@ class Macbook(
     }
 
     override fun toString(): String {
-        return "Macbook(company='$company', name='$name', type='$type', cpu='$cpu', gpu='$gpu', storage='$storage', memory='$memory', language='$language', color='$color', size=$size, releaseYear=$releaseYear, productLink='$productLink', thumbnail='$thumbnail')"
+        return "Macbook(company='$company', name='$name', type='$category', cpu='$cpu', gpu='$gpu', storage='$storage', memory='$memory', language='$language', color='$color', size=$size, releaseYear=$releaseYear, productLink='$productLink', thumbnail='$thumbnail')"
     }
 }

--- a/src/main/kotlin/backend/itracker/crawl/macbook/domain/Macbook.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/domain/Macbook.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.Table
 @Entity
 @Table(name = "macbook")
 class Macbook(
+    val coupangId: Long,
     val company: String,
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/kotlin/backend/itracker/crawl/macbook/domain/MacbookRepository.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/domain/MacbookRepository.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 interface MacbookRepository: JpaRepository<Macbook, Long> {
 
-    fun findByName(name: String): Optional<Macbook>
+    fun findByCoupangId(coupangId: Long): Optional<Macbook>
 
     @Query(
         """

--- a/src/main/kotlin/backend/itracker/crawl/macbook/service/MacbookService.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/service/MacbookService.kt
@@ -13,7 +13,7 @@ class MacbookService (
 
     fun saveAll(macbooks: List<Macbook>) {
         for (macbook in macbooks) {
-            val maybeMacbook = macbookRepository.findByName(macbook.name)
+            val maybeMacbook = macbookRepository.findByCoupangId(macbook.coupangId)
             if (maybeMacbook.isEmpty) {
                 macbookRepository.save(macbook)
                 continue

--- a/src/main/kotlin/backend/itracker/crawl/service/CrawlService.kt
+++ b/src/main/kotlin/backend/itracker/crawl/service/CrawlService.kt
@@ -11,8 +11,8 @@ class CrawlService(
     private val crawler: Crawler
 ) {
 
-    fun crawlMacbook(category: Category): List<Macbook> {
-        val url = "https://pages.coupang.com/p/${category.categoryId}"
+    fun crawlMacbook(crawlTargetCategory: CrawlTargetCategory): List<Macbook> {
+        val url = "https://pages.coupang.com/p/${crawlTargetCategory.categoryId}"
         val products = crawler.crawl(url)
         return crawlMapper.toMacbook(products)
     }

--- a/src/main/kotlin/backend/itracker/crawl/service/CrawlTargetCategory.kt
+++ b/src/main/kotlin/backend/itracker/crawl/service/CrawlTargetCategory.kt
@@ -1,6 +1,6 @@
 package backend.itracker.crawl.service
 
-enum class Category(
+enum class CrawlTargetCategory(
     val categoryId: Long
 ) {
     MACBOOK(84871),

--- a/src/main/kotlin/backend/itracker/crawl/service/MacbookDesirializer.kt
+++ b/src/main/kotlin/backend/itracker/crawl/service/MacbookDesirializer.kt
@@ -10,7 +10,7 @@ import backend.itracker.crawl.service.response.MacbookCrawlResponse
 import backend.itracker.crawl.service.vo.DefaultProduct
 
 enum class MacbookDesirializer(
-    private val category: String,
+    private val subCategory: String,
     private val function: (DefaultProduct) -> MacbookCrawlResponse
 ) {
 
@@ -50,6 +50,7 @@ enum class MacbookDesirializer(
             val language = names[7]
 
             return MacbookCrawlResponse(
+                coupangId = product.productId,
                 company = company,
                 name = product.name,
                 category = ProductCategory.MACBOOK_AIR,
@@ -87,6 +88,7 @@ enum class MacbookDesirializer(
             val language = names[6]
 
             return MacbookCrawlResponse(
+                coupangId = product.productId,
                 company = company,
                 name = product.name,
                 category = ProductCategory.MACBOOK_PRO,
@@ -116,8 +118,8 @@ enum class MacbookDesirializer(
             val company = title[0]
             val releaseYear = title[1].toInt()
             val size = title[4].toInt()
-            val cpu = "${title[2]} ${title[3]} ${title[4]} ${title[5]}"
-            val gpu = "${title[6]} ${title[7]}"
+            val cpu = "${title[5]} ${title[6]} ${title[7]}"
+            val gpu = "${title[8]} ${title[9]}"
 
             val color = names[1]
             val storage = names[2]
@@ -125,6 +127,7 @@ enum class MacbookDesirializer(
             val language = names[4]
 
             return MacbookCrawlResponse(
+                coupangId = product.productId,
                 company = company,
                 name = product.name,
                 category = ProductCategory.MACBOOK_PRO,
@@ -161,6 +164,7 @@ enum class MacbookDesirializer(
             val memory = names[5]
 
             return MacbookCrawlResponse(
+                coupangId = product.productId,
                 company = company,
                 name = product.name,
                 category = ProductCategory.MACBOOK_AIR,
@@ -196,6 +200,7 @@ enum class MacbookDesirializer(
             val memory = names[4]
 
             return MacbookCrawlResponse(
+                coupangId = product.productId,
                 company = company,
                 name = product.name,
                 category = ProductCategory.MACBOOK_AIR,
@@ -219,7 +224,7 @@ enum class MacbookDesirializer(
 
     companion object {
         fun deserialize(product: DefaultProduct): MacbookCrawlResponse {
-            val category = entries.firstOrNull { it.category == product.category }
+            val category = entries.firstOrNull { it.subCategory == product.category }
                 ?: throw IllegalStateException("지원하지 않는 맥북 카테고리 입니다. category : ${product.category}")
 
             return category.function(product)

--- a/src/main/kotlin/backend/itracker/crawl/service/MacbookDesirializer.kt
+++ b/src/main/kotlin/backend/itracker/crawl/service/MacbookDesirializer.kt
@@ -1,5 +1,6 @@
 package backend.itracker.crawl.service
 
+import backend.itracker.crawl.common.ProductCategory
 import backend.itracker.crawl.service.MacbookDesirializer.Parser.type1
 import backend.itracker.crawl.service.MacbookDesirializer.Parser.type2
 import backend.itracker.crawl.service.MacbookDesirializer.Parser.type3
@@ -40,7 +41,6 @@ enum class MacbookDesirializer(
             val title = names[0].split(" ")
             val company = title[0]
             val releaseYear = title[1].toInt()
-            val type = "${title[2]} ${title[3]}"
             val size = title[4].toInt()
             val color = names[1]
             val cpu = names[2]
@@ -52,7 +52,7 @@ enum class MacbookDesirializer(
             return MacbookCrawlResponse(
                 company = company,
                 name = product.name,
-                type = type,
+                category = ProductCategory.MACBOOK_AIR,
                 cpu = cpu,
                 gpu = gpu,
                 storage = storage,
@@ -78,7 +78,6 @@ enum class MacbookDesirializer(
             val title = names[0].split(" ")
             val company = title[0]
             val releaseYear = title[1].toInt()
-            val type = "${title[2]} ${title[3]}"
             val size = title[4].toInt()
             val color = names[1]
             val cpu = names[2]
@@ -90,7 +89,7 @@ enum class MacbookDesirializer(
             return MacbookCrawlResponse(
                 company = company,
                 name = product.name,
-                type = type,
+                category = ProductCategory.MACBOOK_PRO,
                 cpu = cpu,
                 gpu = gpu,
                 storage = storage,
@@ -116,7 +115,6 @@ enum class MacbookDesirializer(
             val title = names[0].split(" ")
             val company = title[0]
             val releaseYear = title[1].toInt()
-            val type = "${title[2]} ${title[3]}"
             val size = title[4].toInt()
             val cpu = "${title[2]} ${title[3]} ${title[4]} ${title[5]}"
             val gpu = "${title[6]} ${title[7]}"
@@ -129,7 +127,7 @@ enum class MacbookDesirializer(
             return MacbookCrawlResponse(
                 company = company,
                 name = product.name,
-                type = type,
+                category = ProductCategory.MACBOOK_PRO,
                 cpu = cpu,
                 gpu = gpu,
                 storage = storage,
@@ -155,7 +153,6 @@ enum class MacbookDesirializer(
             val title = names[0].split(" ")
             val company = title[0]
             val releaseYear = title[1].toInt()
-            val type = title[2]
             val size = title[3].toInt()
             val color = names[1]
             val cpu = names[2]
@@ -166,7 +163,7 @@ enum class MacbookDesirializer(
             return MacbookCrawlResponse(
                 company = company,
                 name = product.name,
-                type = type,
+                category = ProductCategory.MACBOOK_AIR,
                 cpu = cpu,
                 gpu = gpu,
                 storage = storage,
@@ -192,7 +189,6 @@ enum class MacbookDesirializer(
             val title = names[0].split(" ")
             val company = title[0]
             val releaseYear = title[1].toInt()
-            val type = "${title[2]} ${title[3]}"
             val size = title[4].toInt()
             val color = names[1]
             val cpu = names[2]
@@ -202,7 +198,7 @@ enum class MacbookDesirializer(
             return MacbookCrawlResponse(
                 company = company,
                 name = product.name,
-                type = type,
+                category = ProductCategory.MACBOOK_AIR,
                 cpu = cpu,
                 gpu = "",
                 storage = storage,

--- a/src/main/kotlin/backend/itracker/crawl/service/response/MacbookCrawlResponse.kt
+++ b/src/main/kotlin/backend/itracker/crawl/service/response/MacbookCrawlResponse.kt
@@ -8,6 +8,7 @@ import backend.itracker.crawl.service.vo.DefaultProduct
 import java.math.BigDecimal
 
 data class MacbookCrawlResponse(
+    val coupangId: Long,
     val company: String,
     val name: String,
     val category: ProductCategory,
@@ -34,6 +35,7 @@ data class MacbookCrawlResponse(
 
     fun toDomain(): Macbook {
         val macbook = Macbook(
+            coupangId = coupangId,
             company = company,
             name = name,
             category = category,
@@ -50,13 +52,13 @@ data class MacbookCrawlResponse(
             isOutOfStock = isOutOfStock
         )
 
-            macbook.addPrice(
-                MacbookPrice(
-            discountPercentage = discountPercentage,
-            basePrice = basePrice,
-            currentPrice = discountPrice
-        )
+        macbook.addPrice(
+            MacbookPrice(
+                discountPercentage = discountPercentage,
+                basePrice = basePrice,
+                currentPrice = discountPrice
             )
+        )
         return macbook
     }
 }

--- a/src/main/kotlin/backend/itracker/crawl/service/response/MacbookCrawlResponse.kt
+++ b/src/main/kotlin/backend/itracker/crawl/service/response/MacbookCrawlResponse.kt
@@ -1,5 +1,6 @@
 package backend.itracker.crawl.service.response
 
+import backend.itracker.crawl.common.ProductCategory
 import backend.itracker.crawl.macbook.domain.Macbook
 import backend.itracker.crawl.macbook.domain.MacbookPrice
 import backend.itracker.crawl.service.MacbookDesirializer
@@ -9,7 +10,7 @@ import java.math.BigDecimal
 data class MacbookCrawlResponse(
     val company: String,
     val name: String,
-    val type: String,
+    val category: ProductCategory,
     val cpu: String,
     val gpu: String,
     val storage: String,
@@ -35,7 +36,7 @@ data class MacbookCrawlResponse(
         val macbook = Macbook(
             company = company,
             name = name,
-            type = type,
+            category = category,
             cpu = cpu,
             gpu = gpu,
             storage = storage,

--- a/src/main/kotlin/backend/itracker/schedule/SchedulerService.kt
+++ b/src/main/kotlin/backend/itracker/schedule/SchedulerService.kt
@@ -1,8 +1,8 @@
 package backend.itracker.schedule
 
 import backend.itracker.crawl.macbook.service.MacbookService
-import backend.itracker.crawl.service.CrawlTargetCategory
 import backend.itracker.crawl.service.CrawlService
+import backend.itracker.crawl.service.CrawlTargetCategory
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/backend/itracker/schedule/SchedulerService.kt
+++ b/src/main/kotlin/backend/itracker/schedule/SchedulerService.kt
@@ -1,7 +1,7 @@
 package backend.itracker.schedule
 
 import backend.itracker.crawl.macbook.service.MacbookService
-import backend.itracker.crawl.service.Category
+import backend.itracker.crawl.service.CrawlTargetCategory
 import backend.itracker.crawl.service.CrawlService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.scheduling.annotation.Scheduled
@@ -20,7 +20,7 @@ class SchedulerService(
     fun crawlMacbook() {
         logger.info { "맥북 크롤링 시작. " }
         val times = measureTime {
-            val macbooks = crawlService.crawlMacbook(Category.MACBOOK)
+            val macbooks = crawlService.crawlMacbook(CrawlTargetCategory.MACBOOK)
             macbookService.saveAll(macbooks)
         }
         logger.info { "맥북 크롤링 끝. 시간: $times" }

--- a/src/main/kotlin/backend/itracker/tracker/controller/ProductController.kt
+++ b/src/main/kotlin/backend/itracker/tracker/controller/ProductController.kt
@@ -1,7 +1,7 @@
 package backend.itracker.tracker.controller
 
 import backend.itracker.crawl.macbook.service.MacbookService
-import backend.itracker.crawl.service.Category
+import backend.itracker.crawl.service.CrawlTargetCategory
 import backend.itracker.tracker.controller.response.Pages
 import backend.itracker.tracker.controller.response.ProductResponse
 import org.springframework.http.ResponseEntity
@@ -17,10 +17,10 @@ class ProductController(
     @GetMapping("/products/{categoryId}")
     fun findProductsByCategory(@PathVariable categoryId: Long): ResponseEntity<Pages<ProductResponse>> {
 
-        val category = (Category.entries.find { it.categoryId == categoryId }
+        val crawlTargetCategory = (CrawlTargetCategory.entries.find { it.categoryId == categoryId }
             ?: return ResponseEntity.notFound().build())
 
-        if (category == Category.MACBOOK) {
+        if (crawlTargetCategory == CrawlTargetCategory.MACBOOK) {
             val macbooks = macbookService.findAllWithRecentPrices()
             return ResponseEntity.ok(
                 Pages(data = macbooks.map {

--- a/src/main/kotlin/backend/itracker/tracker/controller/ProductController.kt
+++ b/src/main/kotlin/backend/itracker/tracker/controller/ProductController.kt
@@ -1,7 +1,7 @@
 package backend.itracker.tracker.controller
 
+import backend.itracker.crawl.common.ProductCategory
 import backend.itracker.crawl.macbook.service.MacbookService
-import backend.itracker.crawl.service.CrawlTargetCategory
 import backend.itracker.tracker.controller.response.Pages
 import backend.itracker.tracker.controller.response.ProductResponse
 import org.springframework.http.ResponseEntity
@@ -14,20 +14,23 @@ class ProductController(
     private val macbookService: MacbookService
 ) {
 
-    @GetMapping("/products/{categoryId}")
-    fun findProductsByCategory(@PathVariable categoryId: Long): ResponseEntity<Pages<ProductResponse>> {
+    @GetMapping("/api/products/{categoryId}")
+    fun findProductsByCategory(@PathVariable category: String): ResponseEntity<Pages<ProductResponse>> {
 
-        val crawlTargetCategory = (CrawlTargetCategory.entries.find { it.categoryId == categoryId }
-            ?: return ResponseEntity.notFound().build())
+        val crawlTargetCategory = ProductCategory.entries.find { it.name.lowercase() == category.trim() }
+            ?: return ResponseEntity.notFound().build()
 
-        if (crawlTargetCategory == CrawlTargetCategory.MACBOOK) {
+        if (
+            crawlTargetCategory == ProductCategory.MACBOOK_AIR ||
+            crawlTargetCategory == ProductCategory.MACBOOK_PRO
+        ) {
             val macbooks = macbookService.findAllWithRecentPrices()
             return ResponseEntity.ok(
                 Pages(data = macbooks.map {
                     ProductResponse(
                         id = it.id,
                         title = it.name,
-                        category = it.type,
+                        category = it.category.name.lowercase(),
                         inch = it.size,
                         discountPercentage = it.prices.last().discountPercentage,
                         basePrice = it.prices.last().basePrice,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: itracker
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     properties:
       hibernate:
         default_batch_fetch_size: 100

--- a/src/test/kotlin/backend/itracker/crawl/macbook/service/MacbookServiceTest.kt
+++ b/src/test/kotlin/backend/itracker/crawl/macbook/service/MacbookServiceTest.kt
@@ -28,6 +28,7 @@ class MacbookServiceTest {
     @BeforeEach
     fun setUp() {
         macbook = Macbook(
+            coupangId = 1,
             company = "Apple",
             name = "Apple 2024 맥북 에어 13 M3, 미드나이트, M3 8코어, 10코어 GPU, 1TB, 16GB, 35W 듀얼, 한글",
             category = ProductCategory.MACBOOK_AIR,

--- a/src/test/kotlin/backend/itracker/crawl/macbook/service/MacbookServiceTest.kt
+++ b/src/test/kotlin/backend/itracker/crawl/macbook/service/MacbookServiceTest.kt
@@ -1,5 +1,6 @@
 package backend.itracker.crawl.macbook.service
 
+import backend.itracker.crawl.common.ProductCategory
 import backend.itracker.crawl.macbook.domain.Macbook
 import backend.itracker.crawl.macbook.domain.MacbookPrice
 import backend.itracker.crawl.macbook.domain.MacbookRepository
@@ -29,7 +30,7 @@ class MacbookServiceTest {
         macbook = Macbook(
             company = "Apple",
             name = "Apple 2024 맥북 에어 13 M3, 미드나이트, M3 8코어, 10코어 GPU, 1TB, 16GB, 35W 듀얼, 한글",
-            type = "맥북 에어",
+            category = ProductCategory.MACBOOK_AIR,
             cpu = "M3 8코어",
             gpu = "10코어 GPU",
             storage = "1TB",


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #9 

## 참고사항
- 다른 기능기 구현되어 있지 않아서 Macbook air와 Macbook pro만 추가했습니다.
- coupangId가 없으면 정합성이 깨지는 문제가 있어 추가했습니다. 
	- 너무 쿠팡에 의존적인 느낌이 들기도 하는데 쿠팡기반 서비스니까 일단은 넘기기로 했습니다.
	- coupangId가 pk 역할을 할 수 있지만, 추후 id가 변경되는 문제나 인덱스 관련 성능 문제가 생길것도 같아서 기존 id는 냅뒀습니다.