### PR TITLE
맥북 카테고리 api 수정

### DIFF
--- a/src/main/kotlin/backend/itracker/crawl/macbook/domain/MacbookRepository.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/domain/MacbookRepository.kt
@@ -1,7 +1,9 @@
 package backend.itracker.crawl.macbook.domain
 
+import backend.itracker.crawl.common.ProductCategory
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.*
 
 interface MacbookRepository: JpaRepository<Macbook, Long> {
@@ -13,7 +15,8 @@ interface MacbookRepository: JpaRepository<Macbook, Long> {
             select m
             from Macbook m
             join fetch m.prices
+            where m.category = :category
         """
     )
-    fun findAllFetch(): List<Macbook>
+    fun findAllFetchByProductCategory(@Param("category") crawlTargetCategory: ProductCategory): List<Macbook>
 }

--- a/src/main/kotlin/backend/itracker/crawl/macbook/service/MacbookService.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/service/MacbookService.kt
@@ -1,5 +1,6 @@
 package backend.itracker.crawl.macbook.service
 
+import backend.itracker.crawl.common.ProductCategory
 import backend.itracker.crawl.macbook.domain.Macbook
 import backend.itracker.crawl.macbook.domain.MacbookRepository
 import org.springframework.stereotype.Service
@@ -23,8 +24,8 @@ class MacbookService (
     }
 
     @Transactional(readOnly = true)
-    fun findAllWithRecentPrices(): List<Macbook> {
-        val macBooks = macbookRepository.findAllFetch()
+    fun findAllWithRecentPricesByProductGategory(crawlTargetCategory: ProductCategory): List<Macbook> {
+        val macBooks = macbookRepository.findAllFetchByProductCategory(crawlTargetCategory)
         macBooks.map { it.keepOnlyRecentPrice() }
         return macBooks
     }

--- a/src/main/kotlin/backend/itracker/schedule/SchedulerService.kt
+++ b/src/main/kotlin/backend/itracker/schedule/SchedulerService.kt
@@ -16,7 +16,7 @@ class SchedulerService(
     private val macbookService: MacbookService
 ) {
 
-    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 12 * * *", zone = "Asia/Seoul")
     fun crawlMacbook() {
         logger.info { "맥북 크롤링 시작. " }
         val times = measureTime {

--- a/src/main/kotlin/backend/itracker/tracker/controller/ProductController.kt
+++ b/src/main/kotlin/backend/itracker/tracker/controller/ProductController.kt
@@ -14,17 +14,17 @@ class ProductController(
     private val macbookService: MacbookService
 ) {
 
-    @GetMapping("/api/products/{categoryId}")
+    @GetMapping("/api/product/{category}")
     fun findProductsByCategory(@PathVariable category: String): ResponseEntity<Pages<ProductResponse>> {
 
-        val crawlTargetCategory = ProductCategory.entries.find { it.name.lowercase() == category.trim() }
+        val crawlTargetCategory = ProductCategory.entries.find { it.name.lowercase() == category.lowercase().trim() }
             ?: return ResponseEntity.notFound().build()
 
         if (
             crawlTargetCategory == ProductCategory.MACBOOK_AIR ||
             crawlTargetCategory == ProductCategory.MACBOOK_PRO
         ) {
-            val macbooks = macbookService.findAllWithRecentPrices()
+            val macbooks = macbookService.findAllWithRecentPricesByProductGategory(crawlTargetCategory)
             return ResponseEntity.ok(
                 Pages(data = macbooks.map {
                     ProductResponse(

--- a/src/test/kotlin/backend/itracker/crawl/macbook/service/MacbookServiceTest.kt
+++ b/src/test/kotlin/backend/itracker/crawl/macbook/service/MacbookServiceTest.kt
@@ -1,6 +1,6 @@
 package backend.itracker.crawl.macbook.service
 
-import backend.itracker.crawl.common.ProductCategory
+import backend.itracker.crawl.common.ProductCategory.MACBOOK_AIR
 import backend.itracker.crawl.macbook.domain.Macbook
 import backend.itracker.crawl.macbook.domain.MacbookPrice
 import backend.itracker.crawl.macbook.domain.MacbookRepository
@@ -31,7 +31,7 @@ class MacbookServiceTest {
             coupangId = 1,
             company = "Apple",
             name = "Apple 2024 맥북 에어 13 M3, 미드나이트, M3 8코어, 10코어 GPU, 1TB, 16GB, 35W 듀얼, 한글",
-            category = ProductCategory.MACBOOK_AIR,
+            category = MACBOOK_AIR,
             cpu = "M3 8코어",
             gpu = "10코어 GPU",
             storage = "1TB",
@@ -84,7 +84,7 @@ class MacbookServiceTest {
         macbookService.saveAll(listOf(macbook))
 
         // when
-        val actual = macbookService.findAllWithRecentPrices()
+        val actual = macbookService.findAllWithRecentPricesByProductGategory(MACBOOK_AIR)
 
         // then
         assertAll(


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #9

## 참고사항
- 맥북 에어와 맥북 프로일 때 서로 카테고리가 구별되서 응답되게 변경