### PR TITLE
 맥북 최저가 로직 수정

### DIFF
--- a/src/main/kotlin/backend/itracker/crawl/macbook/domain/repository/MacbookRepositoryCustom.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/domain/repository/MacbookRepositoryCustom.kt
@@ -3,8 +3,6 @@ package backend.itracker.crawl.macbook.domain.repository
 import backend.itracker.crawl.common.ProductCategory
 import backend.itracker.crawl.macbook.domain.Macbook
 import backend.itracker.crawl.macbook.service.dto.MacbookFilterCondition
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
 
 interface MacbookRepositoryCustom {
 
@@ -13,9 +11,8 @@ interface MacbookRepositoryCustom {
         filterCondition: MacbookFilterCondition
     ): List<Macbook>
 
-    fun findAllProductsByFilter(
-        category: ProductCategory,
-        filterCondition: MacbookFilterCondition,
-        pageable: Pageable
-    ): PageImpl<Macbook>
+    fun findAllFetchBySearchCondition(
+        productCategory: ProductCategory,
+        filterCondition: MacbookFilterCondition
+    ): List<Macbook>
 }

--- a/src/main/kotlin/backend/itracker/crawl/macbook/domain/repository/MacbookRepositoryImpl.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/domain/repository/MacbookRepositoryImpl.kt
@@ -3,11 +3,10 @@ package backend.itracker.crawl.macbook.domain.repository
 import backend.itracker.crawl.common.ProductCategory
 import backend.itracker.crawl.macbook.domain.Macbook
 import backend.itracker.crawl.macbook.domain.QMacbook.macbook
+import backend.itracker.crawl.macbook.domain.QMacbookPrice.macbookPrice
 import backend.itracker.crawl.macbook.service.dto.MacbookFilterCondition
 import com.querydsl.core.types.Predicate
 import com.querydsl.jpa.impl.JPAQueryFactory
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
 
 class MacbookRepositoryImpl(
     private val jpaQueryFactory: JPAQueryFactory
@@ -29,36 +28,21 @@ class MacbookRepositoryImpl(
             ).fetch()
     }
 
-    override fun findAllProductsByFilter(
-        category: ProductCategory,
-        filterCondition: MacbookFilterCondition,
-        pageable: Pageable
-    ): PageImpl<Macbook> {
-        val contents = jpaQueryFactory.selectFrom(macbook)
+    override fun findAllFetchBySearchCondition(
+        productCategory: ProductCategory,
+        filterCondition: MacbookFilterCondition
+    ): List<Macbook> {
+        return jpaQueryFactory
+            .selectFrom(macbook)
+            .join(macbook.prices.macbookPrices, macbookPrice).fetchJoin()
             .where(
                 equalSize(filterCondition.size),
                 equalColor(filterCondition.color),
                 equalChip(filterCondition.processor),
                 equalStorage(filterCondition.storage),
                 equalMemory(filterCondition.memory),
-                equalCategory(category)
-            ).offset(pageable.offset)
-            .limit(pageable.pageSize.toLong())
-            .fetch()
-
-        val total = jpaQueryFactory.selectFrom(macbook)
-            .where(
-                equalSize(filterCondition.size),
-                equalColor(filterCondition.color),
-                equalChip(filterCondition.processor),
-                equalStorage(filterCondition.storage),
-                equalMemory(filterCondition.memory),
-                equalCategory(category)
+                equalCategory(productCategory)
             ).fetch()
-            .count()
-            .toLong()
-
-        return PageImpl(contents, pageable, total)
     }
 
     private fun equalSize(

--- a/src/main/kotlin/backend/itracker/crawl/macbook/service/MacbookService.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/service/MacbookService.kt
@@ -6,8 +6,6 @@ import backend.itracker.crawl.macbook.domain.Macbook
 import backend.itracker.crawl.macbook.domain.repository.MacbookRepository
 import backend.itracker.crawl.macbook.domain.repository.findByIdAllFetch
 import backend.itracker.crawl.macbook.service.dto.MacbookFilterCondition
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -57,13 +55,8 @@ class MacbookService(
     fun findAllProductsByFilter(
         category: ProductCategory,
         macbookFilterCondition: MacbookFilterCondition,
-        pageable: Pageable
-    ): Page<Macbook> {
-        val pageMacbooks =
-            macbookRepository.findAllProductsByFilter(category, macbookFilterCondition, pageable)
-        pageMacbooks.forEach { macbookRepository.findAllPricesByMacbookId(it.id) }
-
-        return pageMacbooks
+    ): List<Macbook> {
+        return macbookRepository.findAllByFilterCondition(category, macbookFilterCondition)
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/backend/itracker/tracker/controller/handler/MacbookHandler.kt
+++ b/src/main/kotlin/backend/itracker/tracker/controller/handler/MacbookHandler.kt
@@ -62,16 +62,13 @@ class MacbookHandler(
     private fun paginate(macbooks: List<Macbook>, pageable: Pageable): List<MacbookResponse> {
         val startElementNumber = pageable.offset.toInt()
         val lastElementNumber = min(startElementNumber + pageable.pageSize, macbooks.size)
-
         if (startElementNumber >= macbooks.size) {
             return emptyList()
         }
 
-        val contents = macbooks.map { MacbookResponse.from(it) }
+        return macbooks.map { MacbookResponse.from(it) }
             .sortedBy { it.discountPercentage }
             .slice(startElementNumber until lastElementNumber)
-
-        return contents
     }
 
     override fun findProductById(productId: Long): CommonProductDetailModel {

--- a/src/main/kotlin/backend/itracker/tracker/controller/handler/MacbookHandler.kt
+++ b/src/main/kotlin/backend/itracker/tracker/controller/handler/MacbookHandler.kt
@@ -11,14 +11,11 @@ import backend.itracker.tracker.service.response.product.CommonProductModel
 import backend.itracker.tracker.service.response.product.macbook.MacbookDetailResponse
 import backend.itracker.tracker.service.response.product.macbook.MacbookResponse
 import backend.itracker.tracker.service.vo.ProductFilter
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 import kotlin.math.min
-
-val logger = KotlinLogging.logger {}
 
 @Component
 class MacbookHandler(
@@ -54,17 +51,10 @@ class MacbookHandler(
         filter: ProductFilter,
         pageable: Pageable,
     ): Page<CommonProductModel> {
-        logger.error { "query start" }
         val macbooks = macbookService.findAllProductsByFilter(
             category,
             MacbookFilterCondition(filter.value),
         )
-        logger.error { "query end" }
-
-        logger.warn { "macbook size ${macbooks.size}" }
-        logger.warn { "pageable pageNumber ${pageable.pageNumber}" }
-        logger.warn { "pageable offset ${pageable.offset}" }
-        logger.warn { "pageable pageSize ${pageable.pageSize}" }
 
         return PageImpl(paginate(macbooks, pageable), pageable, macbooks.size.toLong())
     }
@@ -72,8 +62,6 @@ class MacbookHandler(
     private fun paginate(macbooks: List<Macbook>, pageable: Pageable): List<MacbookResponse> {
         val startElementNumber = pageable.offset.toInt()
         val lastElementNumber = min(startElementNumber + pageable.pageSize, macbooks.size)
-        logger.warn { "start : ${startElementNumber}" }
-        logger.warn { "end : ${lastElementNumber}" }
 
         if (startElementNumber >= macbooks.size) {
             return emptyList()

--- a/src/main/kotlin/backend/itracker/tracker/service/response/product/macbook/MacbookDetailResponse.kt
+++ b/src/main/kotlin/backend/itracker/tracker/service/response/product/macbook/MacbookDetailResponse.kt
@@ -63,7 +63,7 @@ class MacbookDetailResponse(
                 color = macbook.color,
                 label = "역대최저가",
                 imageUrl = macbook.thumbnail,
-                coupangUrl = macbook.coupangLink,
+                coupangUrl = macbook.coupangLink.ifBlank { macbook.productLink },
                 isOutOfStock = macbook.isOutOfStock(),
                 priceInfos = macbook.getRecentPricesByPeriod(SIX_MONTH).macbookPrices
                     .map { CommonPriceInfo.of(it.createdAt, it.currentPrice) }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,12 @@ spring:
       hibernate:
         default_batch_fetch_size: 100
         format_sql: true
-        
+        highlight_sql: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+
 cors:
   allowed-origins: http://localhost:3000
 


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #60

## 참고사항
- 페이지네이션을 DB에서 안하고 서버에서 하는 방향으로 수정
	- 이럴 경우 가격 정보가 너무 많아졌을 때, 메모리 문제가 생길 것 같음
	- 추후에 레디스로 평균가, 최저가, 최고가를 집어넣어서  최적화 해야할 듯
		- 아니면 DB에서 쿼리로 처리하던가...  -> 성능 테스트가 필요할 듯 