### PR TITLE
에어팟 상품 API 구현

### DIFF
--- a/src/main/kotlin/backend/itracker/crawl/airpods/domain/AirPods.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/domain/AirPods.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
+import java.math.BigDecimal
 
 @Entity
 @Table(name = "airpods")
@@ -44,6 +45,34 @@ class AirPods(
     fun addPrice(airPodsPrice: AirPodsPrice) {
         prices.add(airPodsPrice)
         airPodsPrice.changeAirPods(this)
+    }
+
+    fun findCurrentPrice(): BigDecimal {
+        return prices.findCurrentPrice()
+    }
+
+    fun findAveragePrice(): BigDecimal {
+        return prices.findAveragePrice()
+    }
+
+    fun findAllTimeHighPrice(): BigDecimal {
+        return prices.findAllTimeHighPrice()
+    }
+
+    fun findAllTimeLowPrice(): BigDecimal {
+        return prices.findAllTimeLowPrice()
+    }
+
+    fun findDiscountPercentage(): Int {
+        return prices.findTodayDiscountPercentage()
+    }
+
+    fun isOutOfStock(): Boolean {
+        return prices.isOutOfStock()
+    }
+
+    fun isAllTimeLowPrice(): Boolean {
+        return prices.isAllTimeLowPrice()
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/backend/itracker/crawl/airpods/domain/AirPods.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/domain/AirPods.kt
@@ -31,6 +31,9 @@ class AirPods(
     val productLink: String,
 
     @Column(columnDefinition = "TEXT")
+    var partnersLink: String = "",
+
+    @Column(columnDefinition = "TEXT")
     val thumbnail: String,
 
     @Embedded
@@ -76,11 +79,15 @@ class AirPods(
         return prices.isAllTimeLowPrice()
     }
 
+    fun changePartnersLink(partnersLink: String) {
+        this.partnersLink = partnersLink
+    }
+
     fun getRecentPricesByPeriod(period: Period): AirPodsPrices {
         return prices.getRecentPricesByPeriod(period)
     }
 
     override fun toString(): String {
-        return "AirPods(coupangId=$coupangId, company='$company', releaseYear=$releaseYear, generation=$generation, canWirelessCharging=$canWirelessCharging, chargingType='$chargingType', color='$color', category=$category, name='$name', productLink='$productLink', thumbnail='$thumbnail')"
+        return "AirPods(coupangId=$coupangId, company='$company', releaseYear=$releaseYear, generation=$generation, canWirelessCharging=$canWirelessCharging, chargingType='$chargingType', color='$color', category=$category, name='$name', productLink='$productLink', partnersLink='$partnersLink', thumbnail='$thumbnail')"
     }
 }

--- a/src/main/kotlin/backend/itracker/crawl/airpods/domain/AirPods.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/domain/AirPods.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
 import java.math.BigDecimal
+import java.time.Period
 
 @Entity
 @Table(name = "airpods")
@@ -73,6 +74,10 @@ class AirPods(
 
     fun isAllTimeLowPrice(): Boolean {
         return prices.isAllTimeLowPrice()
+    }
+
+    fun getRecentPricesByPeriod(period: Period): AirPodsPrices {
+        return prices.getRecentPricesByPeriod(period)
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/backend/itracker/crawl/airpods/domain/AirPodsPrices.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/domain/AirPodsPrices.kt
@@ -3,6 +3,12 @@ package backend.itracker.crawl.airpods.domain
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Embeddable
 import jakarta.persistence.OneToMany
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDateTime
+import java.time.Period
+
+private val PERCENT_BASE = BigDecimal.valueOf(100)
 
 @Embeddable
 class AirPodsPrices(
@@ -12,5 +18,48 @@ class AirPodsPrices(
 
     fun add(targetAirPodsPrice: AirPodsPrice) {
         airPodsPrices.add(targetAirPodsPrice)
+    }
+
+    fun findTodayDiscountPercentage(): Int {
+        val currentPrice = findCurrentPrice()
+        val averagePrice = findAveragePrice()
+
+        val priceDiff = (currentPrice - averagePrice) / averagePrice
+        return priceDiff.multiply(PERCENT_BASE).toInt()
+    }
+
+    fun findCurrentPrice(): BigDecimal {
+        return airPodsPrices.maxBy { it.createdAt }.currentPrice
+    }
+
+    fun findAveragePrice(): BigDecimal {
+        return airPodsPrices.sumOf { it.currentPrice }
+            .divide(BigDecimal.valueOf(airPodsPrices.size.toLong()), 2, RoundingMode.HALF_UP)
+    }
+
+    fun isOutOfStock(): Boolean {
+        return airPodsPrices.maxBy { it.createdAt }.isOutOfStock
+    }
+
+    fun findAllTimeHighPrice(): BigDecimal {
+        return airPodsPrices.maxOf { it.currentPrice }
+    }
+
+    fun findAllTimeLowPrice(): BigDecimal {
+        return airPodsPrices.minOf { it.currentPrice }
+    }
+
+    fun isAllTimeLowPrice(): Boolean {
+        val todayPrice = airPodsPrices.maxBy { it.createdAt }.currentPrice
+
+        return todayPrice <= findAllTimeLowPrice()
+    }
+
+    fun getRecentPricesByPeriod(period: Period): AirPodsPrices {
+        val startDate = LocalDateTime.now().minus(period)
+        val prices = airPodsPrices.filter { it.createdAt.isAfter(startDate) }
+            .sortedBy { it.createdAt }
+
+        return AirPodsPrices(prices.toMutableList())
     }
 }

--- a/src/main/kotlin/backend/itracker/crawl/airpods/domain/repository/AirPodsRepository.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/domain/repository/AirPodsRepository.kt
@@ -41,4 +41,6 @@ interface AirPodsRepository : JpaRepository<AirPods, Long> {
     """
     )
     fun findByIdAllFetch(@Param("id") id: Long): Optional<AirPods>
+
+    fun findByIdBetween(startId: Long, endId: Long): List<AirPods>
 }

--- a/src/main/kotlin/backend/itracker/crawl/airpods/domain/repository/AirPodsRepository.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/domain/repository/AirPodsRepository.kt
@@ -17,7 +17,7 @@ interface AirPodsRepository : JpaRepository<AirPods, Long> {
         """
             select a
             from AirPods a
-            join fetch a.prices
+            join fetch a.prices.airPodsPrices
             where a.coupangId = :coupangId
         """
     )
@@ -27,7 +27,7 @@ interface AirPodsRepository : JpaRepository<AirPods, Long> {
         """
             select a
             from AirPods a
-            join fetch a.prices
+            join fetch a.prices.airPodsPrices
         """
     )
     fun findAllFetch(): List<AirPods>
@@ -36,7 +36,7 @@ interface AirPodsRepository : JpaRepository<AirPods, Long> {
         """
             select a
             from AirPods a
-            join fetch a.prices
+            join fetch a.prices.airPodsPrices
             where a.id = :id
     """
     )

--- a/src/main/kotlin/backend/itracker/crawl/airpods/domain/repository/AirPodsRepository.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/domain/repository/AirPodsRepository.kt
@@ -5,6 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.util.*
+import kotlin.jvm.optionals.getOrNull
+
+fun AirPodsRepository.getByIdAllFetch(id: Long): AirPods {
+    return findByIdAllFetch(id).getOrNull() ?: throw NoSuchElementException("해당하는 id의 AirPods가 없습니다. id: $id")
+}
 
 interface AirPodsRepository : JpaRepository<AirPods, Long> {
 
@@ -26,4 +31,14 @@ interface AirPodsRepository : JpaRepository<AirPods, Long> {
         """
     )
     fun findAllFetch(): List<AirPods>
+
+    @Query(
+        """
+            select a
+            from AirPods a
+            join fetch a.prices
+            where a.id = :id
+    """
+    )
+    fun findByIdAllFetch(@Param("id") id: Long): Optional<AirPods>
 }

--- a/src/main/kotlin/backend/itracker/crawl/airpods/domain/repository/AirPodsRepository.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/domain/repository/AirPodsRepository.kt
@@ -17,4 +17,13 @@ interface AirPodsRepository : JpaRepository<AirPods, Long> {
         """
     )
     fun findByCoupangId(@Param("coupangId") coupangId: Long): Optional<AirPods>
+
+    @Query(
+        """
+            select a
+            from AirPods a
+            join fetch a.prices
+        """
+    )
+    fun findAllFetch(): List<AirPods>
 }

--- a/src/main/kotlin/backend/itracker/crawl/airpods/service/AirPodsService.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/service/AirPodsService.kt
@@ -21,4 +21,9 @@ class AirPodsService(
             maybeAirPods.get().addAllPrices(airPods.prices)
         }
     }
+
+    @Transactional(readOnly = true)
+    fun findAllFetch(): List<AirPods> {
+        return airPodsRepository.findAllFetch()
+    }
 }

--- a/src/main/kotlin/backend/itracker/crawl/airpods/service/AirPodsService.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/service/AirPodsService.kt
@@ -2,6 +2,7 @@ package backend.itracker.crawl.airpods.service
 
 import backend.itracker.crawl.airpods.domain.AirPods
 import backend.itracker.crawl.airpods.domain.repository.AirPodsRepository
+import backend.itracker.crawl.airpods.domain.repository.getByIdAllFetch
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -25,5 +26,10 @@ class AirPodsService(
     @Transactional(readOnly = true)
     fun findAllFetch(): List<AirPods> {
         return airPodsRepository.findAllFetch()
+    }
+
+    @Transactional(readOnly = true)
+    fun findByIdAllFetch(productId: Long): AirPods {
+        return airPodsRepository.getByIdAllFetch(productId)
     }
 }

--- a/src/main/kotlin/backend/itracker/crawl/airpods/service/AirPodsService.kt
+++ b/src/main/kotlin/backend/itracker/crawl/airpods/service/AirPodsService.kt
@@ -3,6 +3,7 @@ package backend.itracker.crawl.airpods.service
 import backend.itracker.crawl.airpods.domain.AirPods
 import backend.itracker.crawl.airpods.domain.repository.AirPodsRepository
 import backend.itracker.crawl.airpods.domain.repository.getByIdAllFetch
+import backend.itracker.crawl.common.PartnersLinkInfo
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -11,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional
 class AirPodsService(
     private val airPodsRepository: AirPodsRepository
 ) {
-    
+
     fun saveAll(airPodses: List<AirPods>) {
         for (airPods in airPodses) {
             val maybeAirPods = airPodsRepository.findByCoupangId(airPods.coupangId)
@@ -23,6 +24,14 @@ class AirPodsService(
         }
     }
 
+    fun updateAllPartnersLink(linkInformation: List<PartnersLinkInfo>) {
+        val airPodses = airPodsRepository.findAll()
+        linkInformation.forEach { info ->
+            airPodses.filter { airPods -> airPods.productLink == info.originalUrl }
+                .map { it.changePartnersLink(info.partnersUrl) }
+        }
+    }
+
     @Transactional(readOnly = true)
     fun findAllFetch(): List<AirPods> {
         return airPodsRepository.findAllFetch()
@@ -31,5 +40,10 @@ class AirPodsService(
     @Transactional(readOnly = true)
     fun findByIdAllFetch(productId: Long): AirPods {
         return airPodsRepository.getByIdAllFetch(productId)
+    }
+
+    @Transactional(readOnly = true)
+    fun findByIdBetween(startId: Long, endId: Long): List<AirPods> {
+        return airPodsRepository.findByIdBetween(startId, endId)
     }
 }

--- a/src/main/kotlin/backend/itracker/crawl/common/PartnersLinkInfo.kt
+++ b/src/main/kotlin/backend/itracker/crawl/common/PartnersLinkInfo.kt
@@ -1,6 +1,6 @@
 package backend.itracker.crawl.common
 
-data class CoupangLinkInfo(
+data class PartnersLinkInfo(
     val originalUrl: String,
     val partnersUrl: String
 )

--- a/src/main/kotlin/backend/itracker/crawl/macbook/domain/Macbook.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/domain/Macbook.kt
@@ -36,7 +36,7 @@ class Macbook(
     val productLink: String,
 
     @Column(columnDefinition = "TEXT")
-    var coupangLink: String = "",
+    var partnersLink: String = "",
 
     @Column(columnDefinition = "TEXT")
     val thumbnail: String,
@@ -84,8 +84,8 @@ class Macbook(
         return prices.isAllTimeLowPrice()
     }
 
-    fun changeCoupangLink(coupangLink: String) {
-        this.coupangLink = coupangLink
+    fun changePartnersLink(partnersLink: String) {
+        this.partnersLink = partnersLink
     }
 
     fun getRecentPricesByPeriod(period: Period): MacbookPrices {
@@ -93,6 +93,6 @@ class Macbook(
     }
 
     override fun toString(): String {
-        return "Macbook(coupangId=$coupangId, company='$company', name='$name', category=$category, chip='$chip', cpu='$cpu', gpu='$gpu', storage='$storage', memory='$memory', language='$language', color='$color', size=$size, releaseYear=$releaseYear, productLink='$productLink', coupangLink='$coupangLink', thumbnail='$thumbnail')"
+        return "Macbook(coupangId=$coupangId, company='$company', name='$name', chip='$chip', cpu='$cpu', gpu='$gpu', storage='$storage', memory='$memory', language='$language', color='$color', size=$size, releaseYear=$releaseYear, category=$category, productLink='$productLink', partnersLink='$partnersLink', thumbnail='$thumbnail')"
     }
 }

--- a/src/main/kotlin/backend/itracker/crawl/macbook/domain/repository/MacbookRepository.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/domain/repository/MacbookRepository.kt
@@ -20,7 +20,7 @@ interface MacbookRepository: JpaRepository<Macbook, Long>, MacbookRepositoryCust
         """
             select m
             from Macbook m
-            join fetch m.prices
+            join fetch m.prices.macbookPrices
             where m.category = :category
         """
     )
@@ -30,7 +30,7 @@ interface MacbookRepository: JpaRepository<Macbook, Long>, MacbookRepositoryCust
         """
             select m
             from Macbook m
-            join fetch m.prices
+            join fetch m.prices.macbookPrices
             where m.id = :id
         """
     )

--- a/src/main/kotlin/backend/itracker/crawl/macbook/service/MacbookService.kt
+++ b/src/main/kotlin/backend/itracker/crawl/macbook/service/MacbookService.kt
@@ -1,6 +1,6 @@
 package backend.itracker.crawl.macbook.service
 
-import backend.itracker.crawl.common.CoupangLinkInfo
+import backend.itracker.crawl.common.PartnersLinkInfo
 import backend.itracker.crawl.macbook.domain.Macbook
 import backend.itracker.crawl.macbook.domain.MacbookCategory
 import backend.itracker.crawl.macbook.domain.repository.MacbookRepository
@@ -26,13 +26,11 @@ class MacbookService(
         }
     }
 
-    fun updateAllCoupangLink(coupangLinks: List<CoupangLinkInfo>) {
+    fun updateAllPartnersLink(partnersLinkInformation: List<PartnersLinkInfo>) {
         val macbooks = macbookRepository.findAll()
-        coupangLinks.forEach { link ->
-            val coupangLink = link.partnersUrl
-
-            macbooks.filter { macbook -> macbook.productLink == link.originalUrl }
-                .map { it.changeCoupangLink(coupangLink) }
+        partnersLinkInformation.forEach { info ->
+            macbooks.filter { macbook -> macbook.productLink == info.originalUrl }
+                .map { it.changePartnersLink(info.partnersUrl) }
         }
     }
 

--- a/src/main/kotlin/backend/itracker/tracker/controller/CoupangPartnersController.kt
+++ b/src/main/kotlin/backend/itracker/tracker/controller/CoupangPartnersController.kt
@@ -1,5 +1,6 @@
 package backend.itracker.tracker.controller
 
+import backend.itracker.crawl.airpods.service.AirPodsService
 import backend.itracker.crawl.common.PartnersLinkInfo
 import backend.itracker.crawl.common.ProductCategory
 import backend.itracker.crawl.macbook.service.MacbookService
@@ -13,7 +14,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class CoupangPartnersController(
     private val coupangPartnersService: CoupangPartnersService,
-    private val macbookService: MacbookService
+    private val macbookService: MacbookService,
+    private val airPodsService: AirPodsService
 ) {
 
     @PatchMapping("/api/v1/coupang/deeplink/{category}")
@@ -26,6 +28,12 @@ class CoupangPartnersController(
             ProductCategory.MACBOOK_AIR, ProductCategory.MACBOOK_PRO -> {
                 val partnersLink = coupangPartnersService.updateAllMacbookPartnersLink(start, end)
                 macbookService.updateAllPartnersLink(partnersLink.map { PartnersLinkInfo(it.originalUrl, it.shortenUrl)})
+                ResponseEntity.ok().build()
+            }
+
+            ProductCategory.AIRPODS -> {
+                val partnersLink = coupangPartnersService.updateAllAirPodsPartnersLink(start, end)
+                airPodsService.updateAllPartnersLink(partnersLink.map { PartnersLinkInfo(it.originalUrl, it.shortenUrl)})
                 ResponseEntity.ok().build()
             }
 

--- a/src/main/kotlin/backend/itracker/tracker/controller/CoupangPartnersController.kt
+++ b/src/main/kotlin/backend/itracker/tracker/controller/CoupangPartnersController.kt
@@ -1,6 +1,6 @@
 package backend.itracker.tracker.controller
 
-import backend.itracker.crawl.common.CoupangLinkInfo
+import backend.itracker.crawl.common.PartnersLinkInfo
 import backend.itracker.crawl.common.ProductCategory
 import backend.itracker.crawl.macbook.service.MacbookService
 import backend.itracker.tracker.service.service.CoupangPartnersService
@@ -17,15 +17,15 @@ class CoupangPartnersController(
 ) {
 
     @PatchMapping("/api/v1/coupang/deeplink/{category}")
-    fun updateCoupangLink(
+    fun updatePartnersLink(
         @PathVariable category: ProductCategory,
         @RequestParam start: Long,
         @RequestParam end: Long,
     ): ResponseEntity<Unit> {
         return when (category) {
             ProductCategory.MACBOOK_AIR, ProductCategory.MACBOOK_PRO -> {
-                val deeplinks = coupangPartnersService.updateAllMacbookCoupangLink(start, end)
-                macbookService.updateAllCoupangLink(deeplinks.map { CoupangLinkInfo(it.originalUrl, it.shortenUrl)})
+                val partnersLink = coupangPartnersService.updateAllMacbookPartnersLink(start, end)
+                macbookService.updateAllPartnersLink(partnersLink.map { PartnersLinkInfo(it.originalUrl, it.shortenUrl)})
                 ResponseEntity.ok().build()
             }
 

--- a/src/main/kotlin/backend/itracker/tracker/controller/handler/AirPodsHandler.kt
+++ b/src/main/kotlin/backend/itracker/tracker/controller/handler/AirPodsHandler.kt
@@ -6,6 +6,7 @@ import backend.itracker.crawl.common.ProductCategory
 import backend.itracker.tracker.service.response.filter.CommonFilterModel
 import backend.itracker.tracker.service.response.product.CommonProductDetailModel
 import backend.itracker.tracker.service.response.product.CommonProductModel
+import backend.itracker.tracker.service.response.product.airpods.AirPodsDetailResponse
 import backend.itracker.tracker.service.response.product.airpods.AirPodsResponse
 import backend.itracker.tracker.service.vo.ProductFilter
 import jakarta.transaction.NotSupportedException
@@ -61,6 +62,8 @@ class AirPodsHandler(
     }
 
     override fun findProductById(productId: Long): CommonProductDetailModel {
-        TODO("Not yet implemented")
+        val airPods = airPodsService.findByIdAllFetch(productId)
+
+        return AirPodsDetailResponse.from(airPods)
     }
 }

--- a/src/main/kotlin/backend/itracker/tracker/controller/handler/AirPodsHandler.kt
+++ b/src/main/kotlin/backend/itracker/tracker/controller/handler/AirPodsHandler.kt
@@ -1,0 +1,66 @@
+package backend.itracker.tracker.controller.handler
+
+import backend.itracker.crawl.airpods.domain.AirPods
+import backend.itracker.crawl.airpods.service.AirPodsService
+import backend.itracker.crawl.common.ProductCategory
+import backend.itracker.tracker.service.response.filter.CommonFilterModel
+import backend.itracker.tracker.service.response.product.CommonProductDetailModel
+import backend.itracker.tracker.service.response.product.CommonProductModel
+import backend.itracker.tracker.service.response.product.airpods.AirPodsResponse
+import backend.itracker.tracker.service.vo.ProductFilter
+import jakarta.transaction.NotSupportedException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Component
+import kotlin.math.min
+
+@Component
+class AirPodsHandler(
+    private val airPodsService: AirPodsService
+) : ProductHandleable {
+    override fun supports(productCategory: ProductCategory): Boolean {
+        return ProductCategory.AIRPODS == productCategory
+    }
+
+    override fun findTopDiscountPercentageProducts(
+        productCategory: ProductCategory,
+        limit: Int
+    ): List<CommonProductModel> {
+        throw NotSupportedException("AirPodsHandler는 최저가 순위를 지원하지 않습니다.")
+    }
+
+    override fun findFilter(productCategory: ProductCategory, filterCondition: ProductFilter): CommonFilterModel {
+        throw NotSupportedException("AirPodsHandler는 필터링를 지원하지 않습니다.")
+    }
+
+    /**
+     * @param category 상품 카테고리  -> 맥북에서만 사용
+     * @param filter 필터 조건 -> 에어팟은 상품 수가 적어서 사용 안 함
+     */
+    override fun findFilteredProductsOrderByDiscountRate(
+        category: ProductCategory,
+        filter: ProductFilter,
+        pageable: Pageable
+    ): Page<CommonProductModel> {
+        val airpods = airPodsService.findAllFetch()
+
+        return PageImpl(paginate(airpods, pageable), pageable, airpods.size.toLong())
+    }
+
+    private fun paginate(airPods: List<AirPods>, pageable: Pageable): List<AirPodsResponse> {
+        val startElementNumber = pageable.offset.toInt()
+        val lastElementNumber = min(startElementNumber + pageable.pageSize, airPods.size)
+        if (startElementNumber >= airPods.size) {
+            return emptyList()
+        }
+
+        return airPods.map { AirPodsResponse.from(it) }
+            .sortedBy { it.discountPercentage }
+            .slice(startElementNumber until lastElementNumber)
+    }
+
+    override fun findProductById(productId: Long): CommonProductDetailModel {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/backend/itracker/tracker/controller/handler/ProductHandleable.kt
+++ b/src/main/kotlin/backend/itracker/tracker/controller/handler/ProductHandleable.kt
@@ -13,10 +13,19 @@ interface ProductHandleable {
 
     fun supports(productCategory: ProductCategory): Boolean
 
+    /**
+     * @param productCategory 상품 카테고리  -> 맥북에서만 사용
+     */
     fun findTopDiscountPercentageProducts(productCategory: ProductCategory, limit: Int): List<CommonProductModel>
 
+    /**
+     * @param productCategory 상품 카테고리  -> 맥북에서만 사용
+     */
     fun findFilter(productCategory: ProductCategory, filterCondition: ProductFilter): CommonFilterModel
 
+    /**
+     * @param category 상품 카테고리  -> 맥북에서만 사용
+     */
     fun findFilteredProductsOrderByDiscountRate(
         category: ProductCategory,
         filter: ProductFilter,

--- a/src/main/kotlin/backend/itracker/tracker/service/request/DeepLinkRequest.kt
+++ b/src/main/kotlin/backend/itracker/tracker/service/request/DeepLinkRequest.kt
@@ -1,6 +1,6 @@
 package backend.itracker.tracker.service.request
 
-data class CoupangLinkRequest(
+data class DeepLinkRequest(
     val coupangUrls: List<String>,
     val subId: String = "itracker"
 )

--- a/src/main/kotlin/backend/itracker/tracker/service/response/CoupangDeepLinkResponse.kt
+++ b/src/main/kotlin/backend/itracker/tracker/service/response/CoupangDeepLinkResponse.kt
@@ -1,6 +1,6 @@
 package backend.itracker.tracker.service.response
 
-data class CoupangLinkResponse(
+data class CoupangDeepLinkResponse(
     val rCode: Int,
     val rMessage: String = "",
     val data: List<Deeplink> = mutableListOf()

--- a/src/main/kotlin/backend/itracker/tracker/service/response/product/airpods/AirPodsDetailResponse.kt
+++ b/src/main/kotlin/backend/itracker/tracker/service/response/product/airpods/AirPodsDetailResponse.kt
@@ -1,0 +1,65 @@
+package backend.itracker.tracker.service.response.product.airpods
+
+import backend.itracker.crawl.airpods.domain.AirPods
+import backend.itracker.crawl.airpods.domain.AirPodsCategory
+import backend.itracker.tracker.service.response.product.CommonPriceInfo
+import backend.itracker.tracker.service.response.product.CommonProductDetailModel
+import java.math.BigDecimal
+
+class AirPodsDetailResponse(
+    val id: Long,
+    val title: String,
+    val generation: Int,
+    val canWirelessCharging: Boolean,
+    val chargingType: String,
+    val category: String,
+    val color: String,
+    val label: Boolean,
+    val imageUrl: String,
+    val coupangUrl: String,
+    val isOutOfStock: Boolean,
+
+    discountPercentage: Int,
+    currentPrice: BigDecimal,
+    allTimeHighPrice: BigDecimal,
+    allTimeLowPrice: BigDecimal,
+    averagePrice: BigDecimal,
+    priceInfos: List<CommonPriceInfo>,
+) : CommonProductDetailModel(
+    discountPercentage,
+    currentPrice,
+    allTimeHighPrice,
+    allTimeLowPrice,
+    averagePrice,
+    priceInfos
+) {
+    companion object {
+        fun from(airPods: AirPods): CommonProductDetailModel {
+            val name = when (airPods.category) {
+                AirPodsCategory.AIRPODS -> "에어팟"
+                AirPodsCategory.AIRPODS_PRO -> "에어팟 프로"
+                AirPodsCategory.AIRPODS_MAX -> "에어팟 맥스"
+            }
+            return AirPodsDetailResponse(
+                id = airPods.id,
+                title = "${airPods.company} ${airPods.releaseYear} $name ${airPods.generation}세대",
+                generation = airPods.generation,
+                canWirelessCharging = airPods.canWirelessCharging,
+                chargingType = airPods.chargingType,
+                category = airPods.category.name.lowercase(),
+                color = airPods.color,
+                label = airPods.isAllTimeLowPrice(),
+                imageUrl = airPods.thumbnail,
+                coupangUrl = airPods.productLink,
+                discountPercentage = airPods.findDiscountPercentage(),
+                currentPrice = airPods.findCurrentPrice(),
+                isOutOfStock = airPods.isOutOfStock(),
+                allTimeHighPrice = airPods.findAllTimeHighPrice(),
+                allTimeLowPrice = airPods.findAllTimeLowPrice(),
+                averagePrice = airPods.findAveragePrice(),
+                priceInfos = airPods.getRecentPricesByPeriod(SIX_MONTH).airPodsPrices
+                    .map { CommonPriceInfo.of(it.createdAt, it.currentPrice) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/backend/itracker/tracker/service/response/product/airpods/AirPodsDetailResponse.kt
+++ b/src/main/kotlin/backend/itracker/tracker/service/response/product/airpods/AirPodsDetailResponse.kt
@@ -50,7 +50,7 @@ class AirPodsDetailResponse(
                 color = airPods.color,
                 label = airPods.isAllTimeLowPrice(),
                 imageUrl = airPods.thumbnail,
-                coupangUrl = airPods.productLink,
+                coupangUrl = airPods.partnersLink.ifBlank { airPods.productLink },
                 discountPercentage = airPods.findDiscountPercentage(),
                 currentPrice = airPods.findCurrentPrice(),
                 isOutOfStock = airPods.isOutOfStock(),

--- a/src/main/kotlin/backend/itracker/tracker/service/response/product/airpods/AirPodsResponse.kt
+++ b/src/main/kotlin/backend/itracker/tracker/service/response/product/airpods/AirPodsResponse.kt
@@ -1,0 +1,46 @@
+package backend.itracker.tracker.service.response.product.airpods
+
+import backend.itracker.crawl.airpods.domain.AirPods
+import backend.itracker.crawl.airpods.domain.AirPodsCategory
+import backend.itracker.tracker.service.response.product.CommonProductModel
+import java.math.BigDecimal
+
+data class AirPodsResponse(
+    val id: Long,
+    val title: String,
+    val generation: Int,
+    val canWirelessCharging: Boolean,
+    val chargingType: String,
+    val category: String,
+    val color: String,
+    val label: Boolean,
+    val imageUrl: String,
+    val discountPercentage: Int,
+    val currentPrice: BigDecimal,
+    val isOutOfStock: Boolean
+) : CommonProductModel {
+
+    companion object {
+        fun from(airPods: AirPods): AirPodsResponse {
+            val name = when (airPods.category) {
+                AirPodsCategory.AIRPODS -> "에어팟"
+                AirPodsCategory.AIRPODS_PRO -> "에어팟 프로"
+                AirPodsCategory.AIRPODS_MAX -> "에어팟 맥스"
+            }
+            return AirPodsResponse(
+                id = airPods.id,
+                title = "${airPods.company} ${airPods.releaseYear} $name ${airPods.generation}세대",
+                generation = airPods.generation,
+                canWirelessCharging = airPods.canWirelessCharging,
+                chargingType = airPods.chargingType,
+                category = airPods.category.name.lowercase(),
+                color = airPods.color,
+                label = airPods.isAllTimeLowPrice(),
+                imageUrl = airPods.thumbnail,
+                discountPercentage = airPods.findDiscountPercentage(),
+                currentPrice = airPods.findCurrentPrice(),
+                isOutOfStock = airPods.isOutOfStock()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/backend/itracker/tracker/service/response/product/macbook/MacbookDetailResponse.kt
+++ b/src/main/kotlin/backend/itracker/tracker/service/response/product/macbook/MacbookDetailResponse.kt
@@ -62,7 +62,7 @@ class MacbookDetailResponse(
                 color = macbook.color,
                 label = macbook.isAllTimeLowPrice(),
                 imageUrl = macbook.thumbnail,
-                coupangUrl = macbook.coupangLink.ifBlank { macbook.productLink },
+                coupangUrl = macbook.partnersLink.ifBlank { macbook.productLink },
                 isOutOfStock = macbook.isOutOfStock(),
                 priceInfos = macbook.getRecentPricesByPeriod(SIX_MONTH).macbookPrices
                     .map { CommonPriceInfo.of(it.createdAt, it.currentPrice) }

--- a/src/main/kotlin/backend/itracker/tracker/service/service/CoupangApiClient.kt
+++ b/src/main/kotlin/backend/itracker/tracker/service/service/CoupangApiClient.kt
@@ -1,8 +1,8 @@
 package backend.itracker.tracker.service.service
 
 import backend.itracker.tracker.service.common.HmacGenerator
-import backend.itracker.tracker.service.request.CoupangLinkRequest
-import backend.itracker.tracker.service.response.CoupangLinkResponse
+import backend.itracker.tracker.service.request.DeepLinkRequest
+import backend.itracker.tracker.service.response.CoupangDeepLinkResponse
 import backend.itracker.tracker.service.response.Deeplink
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Value
@@ -33,18 +33,22 @@ class CoupangApiClient(
     @Value("\${coupang.secret-key}")
     private lateinit var secretKey: String
 
-    fun issueCoupangLinks(originLinks: List<String>): List<Deeplink> {
+    fun issueDeepLinks(originLinks: List<String>): List<Deeplink> {
         val authorization = hmacGenerator.generate(REQUEST_METHOD, URL, secretKey, accessKey)
         val httpHeaders = HttpHeaders().apply {
             set(AUTHORIZATION, authorization)
             set(CONTENT_TYPE, APPLICATION_JSON)
             set(CONTENT_ENCODING, UTF_8)
         }
-        val body = ObjectMapper().writeValueAsString(CoupangLinkRequest(originLinks))
+        val body = ObjectMapper().writeValueAsString(DeepLinkRequest(originLinks))
 
         val request = HttpEntity(body, httpHeaders)
-        val response = restTemplate.postForEntity("$DOMAIN$URL", request, CoupangLinkResponse::class.java)
-        return response.body?.data ?: throw IllegalStateException("Deeplink가 생성중에 오류가 발생했습니다.")
+        val response = restTemplate.postForEntity("$DOMAIN$URL", request, CoupangDeepLinkResponse::class.java)
+        return response.body?.data ?: throw IllegalStateException(
+            """Deeplink가 생성중에 오류가 발생했습니다. 
+            |rCode : ${response.body?.rCode}
+            |rMessage : ${response.body?.rMessage}""".trimMargin()
+        )
     }
 }
 

--- a/src/main/kotlin/backend/itracker/tracker/service/service/CoupangPartnersService.kt
+++ b/src/main/kotlin/backend/itracker/tracker/service/service/CoupangPartnersService.kt
@@ -13,32 +13,32 @@ class CoupangPartnersService(
     private val macbookService: MacbookService
 ) {
 
-    fun updateAllMacbookCoupangLink(
+    fun updateAllMacbookPartnersLink(
         startId: Long,
         endId: Long,
     ): List<Deeplink> {
         val macbooks = macbookService.findByIdBetween(startId, endId)
-        val coupangLinks = requestCoupangLinks(macbooks)
+        val deepLinks = requestDeepLinks(macbooks)
 
-        return coupangLinks
+        return deepLinks
     }
 
-    private fun requestCoupangLinks(macbooks: List<Macbook>): MutableList<Deeplink> {
+    private fun requestDeepLinks(macbooks: List<Macbook>): MutableList<Deeplink> {
         val linkResults = mutableListOf<Deeplink>()
         val queue = ArrayDeque<String>()
 
         macbooks.map { it.productLink }.forEach {
             queue.add(it)
             if (queue.size == MAX_REQUEST_SIZE) {
-                issueCoupangLinks(queue, linkResults)
+                issueDeepLinks(queue, linkResults)
             }
         }
-        issueCoupangLinks(queue, linkResults)
+        issueDeepLinks(queue, linkResults)
 
         return linkResults
     }
 
-    private fun issueCoupangLinks(
+    private fun issueDeepLinks(
         queue: ArrayDeque<String>,
         linkResults: MutableList<Deeplink>
     ) {
@@ -46,7 +46,7 @@ class CoupangPartnersService(
             return
         }
 
-        val response = coupangApiClient.issueCoupangLinks(queue.toList())
+        val response = coupangApiClient.issueDeepLinks(queue.toList())
         linkResults.addAll(response)
         queue.clear()
     }

--- a/src/main/kotlin/backend/itracker/tracker/service/service/CoupangPartnersService.kt
+++ b/src/main/kotlin/backend/itracker/tracker/service/service/CoupangPartnersService.kt
@@ -1,6 +1,6 @@
 package backend.itracker.tracker.service.service
 
-import backend.itracker.crawl.macbook.domain.Macbook
+import backend.itracker.crawl.airpods.service.AirPodsService
 import backend.itracker.crawl.macbook.service.MacbookService
 import backend.itracker.tracker.service.response.Deeplink
 import org.springframework.stereotype.Service
@@ -10,24 +10,34 @@ private const val MAX_REQUEST_SIZE = 20
 @Service
 class CoupangPartnersService(
     private val coupangApiClient: CoupangApiClient,
-    private val macbookService: MacbookService
+    private val macbookService: MacbookService,
+    private val airPodsService: AirPodsService,
 ) {
 
     fun updateAllMacbookPartnersLink(
         startId: Long,
         endId: Long,
     ): List<Deeplink> {
-        val macbooks = macbookService.findByIdBetween(startId, endId)
-        val deepLinks = requestDeepLinks(macbooks)
+        val macbookProductLinks = macbookService.findByIdBetween(startId, endId)
+            .map { it.productLink }
 
-        return deepLinks
+        return requestDeepLinks(macbookProductLinks)
     }
 
-    private fun requestDeepLinks(macbooks: List<Macbook>): MutableList<Deeplink> {
+    fun updateAllAirPodsPartnersLink(
+        startId: Long,
+        end: Long
+    ): List<Deeplink> {
+        val airPodsProductLinks = airPodsService.findByIdBetween(startId, end)
+            .map { it.productLink }
+        return requestDeepLinks(airPodsProductLinks)
+    }
+
+    private fun requestDeepLinks(productLinks: List<String>): MutableList<Deeplink> {
         val linkResults = mutableListOf<Deeplink>()
         val queue = ArrayDeque<String>()
 
-        macbooks.map { it.productLink }.forEach {
+        productLinks.forEach {
             queue.add(it)
             if (queue.size == MAX_REQUEST_SIZE) {
                 issueDeepLinks(queue, linkResults)


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #73 

## 참고사항
- 할인률 top5 제품은 에어팟 상품 개수가 적어서 없이 가는걸로 정했습니다.
- 상세 API, 전체 리스트 반환 API 구현 및 파트너즈 링크 발급 방식 추가